### PR TITLE
Saving configuration values to EEPROM

### DIFF
--- a/Commands.cpp
+++ b/Commands.cpp
@@ -70,7 +70,7 @@ void EEPROMER(unsigned char *Data, unsigned char Length, char action, int eeprom
 
 void UART_Send_Datarate(unsigned char *Datarate)
 {
-
+/*
   switch(*Datarate)
   {
       case 0x00:
@@ -97,6 +97,7 @@ void UART_Send_Datarate(unsigned char *Datarate)
   }
 
   UART_Send_Newline();
+  */
 }
 
 void UART_Send_Channel(unsigned char *Channel)
@@ -136,412 +137,64 @@ void UART_Send_Channel(unsigned char *Channel)
 
 }
 
-void Mac_DevAddr(sBuffer *UART_Buffer, unsigned char *UART_Data)
+
+void Store_Config(sBuffer *UART_Buffer, unsigned char *UART_Data, byte datalen, int eepromstartaddr)
 {
 
-  byte datalen = 4;
-  unsigned char eepromdata[4];
    byte i;
-   int eepromstartaddr = 0;
+   byte tmp = UART_Data[0];
   //Check if it is a set command and there is enough data sent
-  if(UART_Buffer->Data[4] == 's' && UART_Buffer->Counter >= 24)
+  if(UART_Buffer->Data[1] == 's' && UART_Buffer->Counter >= (datalen*2 + 3))
   {
-    UART_Data[0] = ASCII2Hex(UART_Buffer->Data[16],UART_Buffer->Data[17]);
-    UART_Data[1] = ASCII2Hex(UART_Buffer->Data[18],UART_Buffer->Data[19]);
-    UART_Data[2] = ASCII2Hex(UART_Buffer->Data[20],UART_Buffer->Data[21]);
-    UART_Data[3] = ASCII2Hex(UART_Buffer->Data[22],UART_Buffer->Data[23]);
-    //for(i = start; i<datalen; i++)EEPROM.update(i, UART_Data[i]);
+    for(i = 0; i < datalen; i++)
+    {
+      UART_Data[i] = ASCII2Hex(UART_Buffer->Data[(i*2)+3],UART_Buffer->Data[(i*2)+4]);
+    }
+    switch(tmp)
+      {
+        case 'd':
+          if(UART_Data[0] > 0x0F)UART_Data[0] = 0x0F;
+          break;
+        case 'e':
+        case 'f':
+        case 'g':
+          if(UART_Data[0] > 0x01)UART_Data[0] = 0x01;
+          break;
+      }    
     EEPROMER(UART_Data, datalen,'w', eepromstartaddr);
   }
   
-  //for(i = start; i<datalen; i++)UART_Data[i] = EEPROM.read(i);
-  EEPROMER(UART_Data, datalen,'r', eepromstartaddr);
-  Serial.write("DevAddr: ");
-  UART_Send_Data(UART_Data, datalen);
-  UART_Send_Newline();
-}
+    //for(i = 0; i<datalen; i++)UART_Data[i] = EEPROM.read(i+eepromstartaddr);
+    EEPROMER(UART_Data, datalen,'r', eepromstartaddr);
 
-void Mac_NwkSKey(sBuffer *UART_Buffer, unsigned char *UART_Data)
-{
-  unsigned char i,j;
-  byte datalen = 0x10;
-  int eepromstartaddr = 4;
-  //Check if it is a set command and there is enough data sent
-  if(UART_Buffer->Data[4] == 's' && UART_Buffer->Counter >= 48)
-  {
-    for(i = 0,j=0; i < 16; i++,j++)
+   //power
+    if(tmp == 'd')
     {
-      UART_Data[i] = ASCII2Hex(UART_Buffer->Data[(j*2)+16],UART_Buffer->Data[(j*2)+17]);
+      unsigned char RFM_Data;
+      RFM_Data = UART_Data[0] + 0xF0;
+      //Write power to RFM module
+      RFM_Write(0x09,RFM_Data);
     }
-     EEPROMER(UART_Data, datalen, 'w', eepromstartaddr);
-  }
 
-  //Send NwkSkey
-   EEPROMER(UART_Data, datalen, 'r', eepromstartaddr);
-  Serial.write("NwkSKey: ");
-  UART_Send_Data(UART_Data,0x10);
-  UART_Send_Newline();
+    Serial.write(tmp);
+    Serial.write(": ");
+    UART_Send_Data(UART_Data, datalen);
+    UART_Send_Newline();
 }
-
-void Mac_AppSKey(sBuffer *UART_Buffer, unsigned char *UART_Data)    //here
-{
-  unsigned char i, j;
-  byte datalen = 0x10;
-  int eepromstartaddr = 20;
-
-  //Check if it is a set command and there is enough data sent
-  if(UART_Buffer->Data[4] == 's' && UART_Buffer->Counter == 48)
-  {
-    for(i = 0,j=0; i < 16; i++,j++)
-    {
-      UART_Data[i] = ASCII2Hex(UART_Buffer->Data[(j*2)+16],UART_Buffer->Data[(j*2)+17]);
-    }
-     EEPROMER(UART_Data, datalen, 'w', eepromstartaddr);
-  }
-
-   EEPROMER(UART_Data, datalen, 'r', eepromstartaddr);
-  //Send AppSkey
-  Serial.write("AppSKey: ");
-  UART_Send_Data(UART_Data,0x10);
-  UART_Send_Newline();
-}
-/**/
-void Mac_AppKey(sBuffer *UART_Buffer, unsigned char *UART_Data)
-{
-  unsigned char i, j;
-  byte datalen = 0x10;
-  int eepromstartaddr = 36;
-
-  //Check if it is a set command and there is enough data sent
-  if(UART_Buffer->Data[4] == 's' && UART_Buffer->Counter == 47)
-  {
-    for(i = 0,j=0; i < 16; i++,j++)
-    {
-      UART_Data[i] = ASCII2Hex(UART_Buffer->Data[(j*2)+15],UART_Buffer->Data[(j*2)+16]);
-    }
-     EEPROMER(UART_Data, datalen, 'w', eepromstartaddr);
-  }
-
-  //Send AppKey
-   EEPROMER(UART_Data, datalen, 'r', eepromstartaddr);
-  Serial.write("AppKey: ");
-  UART_Send_Data(UART_Data,0x10 );
-  UART_Send_Newline();
-
-}
-/**/
-/*
-void Mac_AppKey(sBuffer *UART_Buffer, unsigned char *AppKey)
-{
-  unsigned char i, j;
-  unsigned char startIndex = 20;
-
-  //Check if it is a set command and there is enough data sent
-  if(UART_Buffer->Data[4] == 's' && UART_Buffer->Counter == 47)
-  {
-    for(i = 0; i < 16; i++)
-    {
-      AppKey[i] = ASCII2Hex(UART_Buffer->Data[(i*2)+15],UART_Buffer->Data[(i*2)+16]);
-    }
-  }
-
-  Serial.println(sizeof(AppKey));
-  //Send AppKey
-  Serial.write("AppKey: ");
-  UART_Send_Data(AppKey,0x10,startIndex);
-  UART_Send_Newline();
-
-}
-/**/
-
-void Mac_AppEUI(sBuffer *UART_Buffer, unsigned char *UART_Data)
-{
-  unsigned char i, j;
-  byte datalen = 0x08;
-  int eepromstartaddr = 52;
-
-  //Check if it is a set command and there is enough data sent
-  if(UART_Buffer->Data[4] == 's' && UART_Buffer->Counter == 31)
-  {
-    for(i = 0,j=0; i < 8; i++,j++)
-    {
-      UART_Data[i] = ASCII2Hex(UART_Buffer->Data[(j*2)+15],UART_Buffer->Data[(j*2)+16]);
-    }
-     EEPROMER(UART_Data, datalen, 'w', eepromstartaddr);
-  }
-
-  //Send AppEUI
-   EEPROMER(UART_Data, datalen, 'r', eepromstartaddr);
-  Serial.write("AppEUI: ");
-  UART_Send_Data(UART_Data,0x08 );
-  UART_Send_Newline();
-}
-
-void Mac_DevEUI(sBuffer *UART_Buffer, unsigned char *UART_Data)
-{
-  unsigned char i, j;
-  byte datalen = 0x08;
-  int eepromstartaddr = 60;
-
-  //Check if it is a set command and there is enough data sent
-  if(UART_Buffer->Data[4] == 's' && UART_Buffer->Counter == 31)
-  {
-    for(i = 0; i < 8; i++)
-    {
-      UART_Data[i] = ASCII2Hex(UART_Buffer->Data[(i*2)+15],UART_Buffer->Data[(i*2)+16]);
-    }
-     EEPROMER(UART_Data, datalen, 'w', eepromstartaddr);
-  }
-
-  //Send DevEUI
-   EEPROMER(UART_Data, datalen, 'r', eepromstartaddr);
-  Serial.write("DevEUI: ");
-  UART_Send_Data(UART_Data,0x08 );
-  UART_Send_Newline();
-}
-
-void Mac_DrTx(sBuffer *UART_Buffer, unsigned char *UART_Data)
-{
-  unsigned char Datarate_Temp;
-  byte datalen = 0x01;
-  int eepromstartaddr = 61;
-
-  //Check if it is a set command and ther is enough data sent
-  if(UART_Buffer->Data[4] == 's' && UART_Buffer->Counter == 15)
-  {
-    //Convert to temp
-    Datarate_Temp = ASCII2Hex(UART_Buffer->Data[13],UART_Buffer->Data[14]);
-
-    //Check if the value is oke
-    if(Datarate_Temp <= 0x06)
-    {
-     // *Datarate = Datarate_Temp;
-       UART_Data[0]= Datarate_Temp;
-        EEPROMER(UART_Data, datalen, 'w', eepromstartaddr);
-    }
-    
-  }
-
-   EEPROMER(UART_Data, datalen, 'r', eepromstartaddr);
-  Serial.write("Datarate Tx: ");
-
-  //unsigned char tmp = UART_Data[0];
-  UART_Send_Datarate(&UART_Data[0]);
-  //UART_Send_Data(UART_Data,0x01 );
-  //UART_Send_Newline();
-}
-
-void Mac_DrRx(sBuffer *UART_Buffer, unsigned char *UART_Data)
-{
-  unsigned char Datarate_Temp;
-  byte datalen = 0x01;
-  int eepromstartaddr = 62;
-
-  //Check if it is a set command and ther is enough data sent
-  if(UART_Buffer->Data[4] == 's' && UART_Buffer->Counter == 15)
-  {
-    //Convert to temp
-    Datarate_Temp = ASCII2Hex(UART_Buffer->Data[13],UART_Buffer->Data[14]);
-
-    //Check if the value is oke
-    if(Datarate_Temp <= 0x06)
-    {
-      //*Datarate = Datarate_Temp;
-      UART_Data[0]= Datarate_Temp;
-       EEPROMER(UART_Data, datalen, 'w', eepromstartaddr);
-    }
-  }
-
-  EEPROMER(UART_Data, datalen,'r', eepromstartaddr);
-  Serial.write("Datarate Rx: ");
-
-  //UART_Send_Datarate(Datarate);
-  UART_Send_Datarate(&UART_Data[0]);
-  //UART_Send_Data(UART_Data,0x01 );
-  //UART_Send_Newline();
-}
-
-void Mac_ChTx(sBuffer *UART_Buffer, unsigned char *UART_Data)
-{
- unsigned char Channel_Temp;
- byte datalen = 0x01;
- int eepromstartaddr = 63;
-
-  //Check if it is a set command and ther is enough data sent
-  if(UART_Buffer->Data[4] == 's' && UART_Buffer->Counter == 15)
-  {
-    //Convert to temp
-    Channel_Temp = ASCII2Hex(UART_Buffer->Data[13],UART_Buffer->Data[14]);
-
-    //Check if the value is oke
-    if(Channel_Temp <= 0x07 || Channel_Temp == 0x10)
-    {
-//      *Channel = Channel_Temp;
-      UART_Data[0]= Channel_Temp;
-      EEPROMER(UART_Data, datalen, 'w', eepromstartaddr);
-    }
-  }
-  EEPROMER(UART_Data, datalen, 'r', eepromstartaddr);
-
-  Serial.write("Channel Tx: ");
-
-  //UART_Send_Channel(Channel);
-   UART_Send_Datarate(&UART_Data[0]);
-}
-
-void Mac_ChRx(sBuffer *UART_Buffer, unsigned char *UART_Data)
-{
-  unsigned char Channel_Temp;
- byte datalen = 0x01;
- int eepromstartaddr = 64;
-
-  //Check if it is a set command and ther is enough data sent
-  if(UART_Buffer->Data[4] == 's' && UART_Buffer->Counter == 15)
-  {
-    //Convert to temp
-    Channel_Temp = ASCII2Hex(UART_Buffer->Data[13],UART_Buffer->Data[14]);
-
-    //Check if the value is oke
-    if(Channel_Temp <= 0x07 || Channel_Temp == 0x10)
-    {
-      //*Channel = Channel_Temp;
-      UART_Data[0]= Channel_Temp;
-      EEPROMER(UART_Data, datalen, 'w', eepromstartaddr);
-    }
-  }
-  EEPROMER(UART_Data, datalen, 'r', eepromstartaddr);
-
-  Serial.write("Channel Rx: ");
-  //UART_Send_Channel(Channel);
-  UART_Send_Datarate(&UART_Data[0]);
-}
-
-void Mac_Power(sBuffer *UART_Buffer, unsigned char *UART_Data)                                                                        //here
-{
-
-  int eepromstartaddr = 65;
-  //Check if it is a set command and there is enough data sent
-  if(UART_Buffer->Data[4] == 's' && UART_Buffer->Counter == 17)
-  {
-    Serial.println("Setting power");
-    unsigned char RFM_Data;
-
-    *UART_Data = ASCII2Hex(UART_Buffer->Data[15],UART_Buffer->Data[16]);
-
-    //Check if power is not over 0x0F
-    if(*UART_Data > 0x0F)
-    {
-      *UART_Data = 0x0F;
-    }
-    EEPROMER(UART_Data, 0x01, 'w', eepromstartaddr);
-    //Set all ther correct bits for the RFM register
-    RFM_Data = *UART_Data + 0xF0;
-    //Write power to RFM module
-    RFM_Write(0x09,RFM_Data); 
-  }
-
-  //Send answer
-  EEPROMER(UART_Data, 0x01, 'r', eepromstartaddr);
-  Serial.write("Power: ");
-  UART_Send_Data(UART_Data,0x01);
-  UART_Send_Newline();
-}
-
-void Mac_Confirm(sBuffer *UART_Buffer, unsigned char *UART_Data)
-{
-  int eepromstartaddr = 66;
-  //Check if it is a set command and there is enough data sent
-  if(UART_Buffer->Data[4] == 's' && UART_Buffer->Counter == 14)
-  {
-    *UART_Data = ASCII2Hex(UART_Buffer->Data[12],UART_Buffer->Data[13]);
-
-    if(*UART_Data >= 0x01)
-    {
-      *UART_Data = 0x01;
-    }
-    EEPROMER(UART_Data, 0x01, 'w', eepromstartaddr);
-  }
-
-  //Send answer
-  EEPROMER(UART_Data, 0x01, 'r', eepromstartaddr);
-  Serial.write("Confirm: ");
-  UART_Send_Data(UART_Data,0x01);
-  UART_Send_Newline();
-}
-
-void Mac_Channel_Hopping(sBuffer *UART_Buffer, unsigned char *UART_Data)
-{
-  int eepromstartaddr = 67;
-  //Check if it is a set command and there is enough data sent
-  if(UART_Buffer->Data[4] == 's' && UART_Buffer->Counter == 16)
-  {
-    *UART_Data = ASCII2Hex(UART_Buffer->Data[14],UART_Buffer->Data[15]);
-
-    if(*UART_Data >= 0x01)
-    {
-      *UART_Data = 0x01;
-    }
-    EEPROMER(UART_Data, 0x01, 'w', eepromstartaddr);
-  }
-
-  //Send answer
-  EEPROMER(UART_Data, 0x01, 'r', eepromstartaddr);
-  Serial.write("Channel Hopping: ");
-  UART_Send_Data(UART_Data,0x01);
-  UART_Send_Newline();
-}
-
-void Mac_Class(sBuffer *UART_Buffer, sSettings *LoRa_Settings)
-{
-   int eepromstartaddr = 68;
-   unsigned char tmp[1];
-  //Check if it is a set command and there is enough data sent
-  if(UART_Buffer->Data[4] == 's' && UART_Buffer->Counter == 16)
-  {
-    LoRa_Settings->Mote_Class = ASCII2Hex(UART_Buffer->Data[14],UART_Buffer->Data[15]);
-
-    if(LoRa_Settings->Mote_Class >= 0x01)
-    {
-      LoRa_Settings->Mote_Class = 0x01;
-    }
-     tmp[0] = LoRa_Settings->Mote_Class;
-    EEPROMER(tmp, 0x01, 'w', eepromstartaddr);
-    
-  }
-
-  //Send answer and switch rfm to standby or receive
-  tmp[0] = LoRa_Settings->Mote_Class;
-  EEPROMER(tmp, 0x01, 'r', eepromstartaddr);
-  Serial.write("Mote Class: ");
-  if(LoRa_Settings->Mote_Class == 0x00)
-  {
-
-    //Switch RFM to standby
-    RFM_Switch_Mode(0x01);
-    
-    Serial.write("A");
-  }
-  else
-  {
-    //Switch RFM to continuou receive
-    RFM_Continuous_Receive(LoRa_Settings);
-    
-    Serial.write("C");
-  }
-  UART_Send_Newline();
-}
-
 void Mac_Data(sBuffer *UART_Buffer, sBuffer *RFM_Buffer)
 {
   unsigned char i;
 
   //Remove the "mac data " bytes
-  UART_Buffer->Counter = UART_Buffer->Counter - 9;
+ // UART_Buffer->Counter = UART_Buffer->Counter - 9;
+  UART_Buffer->Counter = UART_Buffer->Counter - 2;
+
+  Serial.println(UART_Buffer->Counter);
 
   //Check for an even number of received data bytes other wise fill whit 0x00
   if(UART_Buffer->Counter % 2)
   {
-    UART_Buffer->Data[UART_Buffer->Counter + 9] = 0x00;
+    UART_Buffer->Data[UART_Buffer->Counter + 2] = 0x00;
     UART_Buffer->Counter++;
   }
 
@@ -549,7 +202,7 @@ void Mac_Data(sBuffer *UART_Buffer, sBuffer *RFM_Buffer)
 
   for(i = 0x00; i < RFM_Buffer->Counter; i++)
   {
-    RFM_Buffer->Data[i] = ASCII2Hex(UART_Buffer->Data[(i*2)+9],UART_Buffer->Data[(i*2)+10]);
+    RFM_Buffer->Data[i] = ASCII2Hex(UART_Buffer->Data[(i*2)+2],UART_Buffer->Data[(i*2)+3]);
   }
 
   Serial.write("Data ");

--- a/Commands.cpp
+++ b/Commands.cpp
@@ -57,7 +57,6 @@ void UART_Send_Data(unsigned char *Data, unsigned char Length)
 
 void EEPROMER(unsigned char *Data, unsigned char Length, char action, int eepromstartaddr){
   int i;
-  
   switch(action)
   {
     case 'w':                                         
@@ -101,7 +100,7 @@ void UART_Send_Datarate(unsigned char *Datarate)
 }
 
 void UART_Send_Channel(unsigned char *Channel)
-{
+{/*
   switch(*Channel)
   {
     case 0x00:
@@ -134,7 +133,7 @@ void UART_Send_Channel(unsigned char *Channel)
     }
 
     UART_Send_Newline();
-
+*/
 }
 
 
@@ -143,21 +142,24 @@ void Store_Config(sBuffer *UART_Buffer, unsigned char *UART_Data, byte datalen, 
 
    byte i;
    byte tmp = UART_Data[0];
+   if(tmp == '0' || tmp == '1' )return;
+   if(UART_Data[1] == '1')eepromstartaddr += 69;// 0->TTN, 1-> KCS. 2 sets of credentials
+   
   //Check if it is a set command and there is enough data sent
-  if(UART_Buffer->Data[1] == 's' && UART_Buffer->Counter >= (datalen*2 + 3))
+  if(UART_Buffer->Data[2] == 's' && UART_Buffer->Counter >= (datalen*2 + 4))
   {
     for(i = 0; i < datalen; i++)
     {
-      UART_Data[i] = ASCII2Hex(UART_Buffer->Data[(i*2)+3],UART_Buffer->Data[(i*2)+4]);
+      UART_Data[i] = ASCII2Hex(UART_Buffer->Data[(i*2)+4],UART_Buffer->Data[(i*2)+5]);
     }
     switch(tmp)
       {
-        case 'd':
+        case 'e':
           if(UART_Data[0] > 0x0F)UART_Data[0] = 0x0F;
           break;
-        case 'e':
         case 'f':
         case 'g':
+        case 'h':
           if(UART_Data[0] > 0x01)UART_Data[0] = 0x01;
           break;
       }    
@@ -168,7 +170,7 @@ void Store_Config(sBuffer *UART_Buffer, unsigned char *UART_Data, byte datalen, 
     EEPROMER(UART_Data, datalen,'r', eepromstartaddr);
 
    //power
-    if(tmp == 'd')
+    if(tmp == 'e')//power
     {
       unsigned char RFM_Data;
       RFM_Data = UART_Data[0] + 0xF0;

--- a/Commands.h
+++ b/Commands.h
@@ -41,8 +41,6 @@
 void UART_Send_Newline();
 void UART_Send_Data(unsigned char *Data, unsigned char Length);
 void Store_Config(sBuffer *UART_Buffer, unsigned char *UART_Data, byte datalen, int eepromstartaddr);
-void Mac_Channel_Hopping(sBuffer *UART_Buffer, unsigned char *Channel_Hopping);
-void Mac_Class(sBuffer *UART_Buffer, sSettings *LoRa_Settings);
 void Mac_Data(sBuffer *UART_Buffer, sBuffer *RFM_Buffer);
 void EEPROMER(unsigned char *Data, unsigned char Length, char action, int eepromstartaddr);
 

--- a/Commands.h
+++ b/Commands.h
@@ -30,6 +30,7 @@
 #define COMMANDS_H
 
 #include "Struct.h"
+#include <EEPROM.h>
 
 /*
 *****************************************************************************************
@@ -54,6 +55,7 @@ void Mac_Confirm(sBuffer *UART_Buffer, unsigned char *Confirm);
 void Mac_Channel_Hopping(sBuffer *UART_Buffer, unsigned char *Channel_Hopping);
 void Mac_Class(sBuffer *UART_Buffer, sSettings *LoRa_Settings);
 void Mac_Data(sBuffer *UART_Buffer, sBuffer *RFM_Buffer);
+void EEPROMER(unsigned char *Data, unsigned char Length, char action, int eepromstartaddr);
 
 #endif
 

--- a/Commands.h
+++ b/Commands.h
@@ -40,18 +40,7 @@
 
 void UART_Send_Newline();
 void UART_Send_Data(unsigned char *Data, unsigned char Length);
-void Mac_DevAddr(sBuffer *UART_Buffer, unsigned char *DevAddr);
-void Mac_NwkSKey(sBuffer *UART_Buffer, unsigned char *NwkSKey);
-void Mac_AppSKey(sBuffer *UART_Buffer, unsigned char *AppSKey);
-void Mac_AppKey(sBuffer *UART_Buffer, unsigned char *AppKey);
-void Mac_AppEUI(sBuffer *UART_Buffer, unsigned char *AppEUI);
-void Mac_DevEUI(sBuffer *UART_Buffer, unsigned char *DevEUI);
-void Mac_DrTx(sBuffer *UART_Buffer, unsigned char *Datarate);
-void Mac_DrRx(sBuffer *UART_Buffer, unsigned char *Datarate);
-void Mac_ChTx(sBuffer *UART_Buffer, unsigned char *Channel);
-void Mac_ChRx(sBuffer *UART_Buffer, unsigned char *Channel);
-void Mac_Power(sBuffer *UART_Buffer, unsigned char *Power);
-void Mac_Confirm(sBuffer *UART_Buffer, unsigned char *Confirm);
+void Store_Config(sBuffer *UART_Buffer, unsigned char *UART_Data, byte datalen, int eepromstartaddr);
 void Mac_Channel_Hopping(sBuffer *UART_Buffer, unsigned char *Channel_Hopping);
 void Mac_Class(sBuffer *UART_Buffer, sSettings *LoRa_Settings);
 void Mac_Data(sBuffer *UART_Buffer, sBuffer *RFM_Buffer);

--- a/LoRaMAC.cpp
+++ b/LoRaMAC.cpp
@@ -119,11 +119,18 @@ void LORA_Send_Data(sBuffer *Data_Tx, sLoRa_Session *Session_Data, sSettings *Lo
   Message.DevAddr[2] = Session_Data->DevAddr[2];
   Message.DevAddr[3] = Session_Data->DevAddr[3];
 
+
+  
+ // Serial.print("Frame: ");UART_Send_Data(*Session_Data->Frame_Counter, 2);UART_Send_Newline();
+
+ unsigned int tmp = *Session_Data->Frame_Counter;
+ // Serial.print("Frame1:");Serial.println(tmp);
+
   //Set up direction
   Message.Direction = 0x00;
 
   //Load the frame counter from the session data into the message
-  Message.Frame_Counter = *Session_Data->Frame_Counter;
+  Message.Frame_Counter = tmp;//*Session_Data->Frame_Counter;
 
   //Set confirmation
   //Unconfirmed
@@ -151,8 +158,8 @@ void LORA_Send_Data(sBuffer *Data_Tx, sLoRa_Session *Session_Data, sSettings *Lo
   RFM_Data[5] = Message.Frame_Control;
 
   //Load frame counter
-  RFM_Data[6] = (*Session_Data->Frame_Counter & 0x00FF);
-  RFM_Data[7] = ((*Session_Data->Frame_Counter >> 8) & 0x00FF);
+  RFM_Data[6] = (tmp & 0x00FF);//(*Session_Data->Frame_Counter & 0x00FF);
+  RFM_Data[7] = ((tmp >> 8) & 0x00FF);//((*Session_Data->Frame_Counter >> 8) & 0x00FF);
 
   //Set data counter to 8
   RFM_Package.Counter = 8;
@@ -191,12 +198,16 @@ void LORA_Send_Data(sBuffer *Data_Tx, sLoRa_Session *Session_Data, sSettings *Lo
 
   //Add MIC length to RFM package length
   RFM_Package.Counter = RFM_Package.Counter + 4;
-
+ // Serial.print("Frame: ");UART_Send_Data(RFM_Data, RFM_Package.Counter+i);UART_Send_Newline();
   //Send Package
   RFM_Send_Package(&RFM_Package, LoRa_Settings);
 
+  //UART_Send_Data(*Session_Data->Frame_Counter, 2);
+
+  
+
   //Raise Frame counter
-  if(*Session_Data->Frame_Counter != 0xFFFF)
+   if(*Session_Data->Frame_Counter != 0xFFFF)
   {
     //Raise frame counter
     *Session_Data->Frame_Counter = *Session_Data->Frame_Counter + 1;

--- a/Nexus_LoRaWAN.ino
+++ b/Nexus_LoRaWAN.ino
@@ -437,36 +437,6 @@ void loop()
            break;
           
       }
-     
-      //Check for commands
-      /*
-       * MAC command type
-       */
-       /*
-  
-        //Check for reset command
-        if(UART_Data[4] == 'r' && UART_Data[5] == 'e' && UART_Data[6] == 's' && UART_Data[7] == 'e' && UART_Data[8] == 't')
-        {
-
-        }
-        /*
-        //Check for a set or get command
-        if((UART_Data[4] == 's' || UART_Data[4] == 'g') && UART_Data[5] == 'e' && UART_Data[6] == 't')
-        {   
-
-          //mac set/get class
-          if(UART_Data[8] == 'c' && UART_Data[9] == 'l' && UART_Data[10] == 'a' && UART_Data[11] == 's' && UART_Data[12] == 's')
-          {
-            Mac_Class(&UART_Rx_Buffer, &LoRa_Settings);
-
-            //Reset RFM command
-            RFM_Command_Status = NO_RFM_COMMAND;
-          }
-
-        
-        }
-      }
-  /**/
       //Set UART status to data done to clear for next command
       UART_Status = UART_DATA_DONE;
     }

--- a/Nexus_LoRaWAN.ino
+++ b/Nexus_LoRaWAN.ino
@@ -272,6 +272,8 @@ void loop()
     {
       byte datalen;
       int eepromaddr;
+      char tmp = UART_Data[0];
+      char whichdevice = UART_Data[1];
       switch(UART_Data[0])
       {
         case '0':
@@ -331,7 +333,7 @@ void loop()
           datalen = 0x08;
           eepromaddr = 60;
           break;
-         case '9':
+         /*case '9':
          //mac set/get drrx
           datalen = 0x01;
           eepromaddr = 61;
@@ -372,12 +374,53 @@ void loop()
           datalen = 0x01;
           eepromaddr = 68;
           break;
+         case 'h':
+         //mac set/get class
+          datalen = 0x01;
+          eepromaddr = 68;
+          break;
+         case 'i':
+         //mac set/get class
+          datalen = 0x01;
+          eepromaddr = 68;
+          break;
+         case 'j':
+         //mac set/get class
+          datalen = 0x01;
+          eepromaddr = 68;
+          break;
+         case 'k':
+         //mac set/get class
+          datalen = 0x01;
+          eepromaddr = 68;
+          break;
+         case 'l':
+         //mac set/get class
+          datalen = 0x01;
+          eepromaddr = 68;
+          break;
+          */
+         case 'a':
+         case 'b':
+         case 'c':
+         case 'd':
+         case 'e':
+         case 'f':
+         case 'g':
+         case 'h':
+         case 'i':
+         case 'j':
+         case 'k':
+         case 'l':
+         case 'm':
+          datalen = 0x01;
+          eepromaddr = 61 + (tmp - 'a');
+          break;
          case 'z':
           break;
           
           
       }
-      char tmp = UART_Data[0];
       Store_Config(&UART_Rx_Buffer, UART_Data, datalen, eepromaddr);
       switch(tmp)
       {
@@ -391,7 +434,6 @@ void loop()
           Frame_Counter_Tx = 0x0000;
           
       }
-      
       switch(tmp)
       {
         case '3':
@@ -400,24 +442,24 @@ void loop()
         case '6':
         case '7':
         case '8':
-        case '9':
         case 'a':
         case 'b':
         case 'c':
-        case 'e':
+        case 'd':
         case 'f':
         case 'g':
+        case 'h':
           RFM_Command_Status = NO_RFM_COMMAND;
           
       }
       switch(tmp)
       {
-        case 'd':
-          EEPROMER(UART_Data, 0x01,'r', 65);
+        case 'e':
+          EEPROMER(UART_Data, 0x01,'r', 65+(whichdevice=='0'?0:69));
           LoRa_Settings.Transmit_Power = UART_Data[0];
           break;
-        case 'g':
-          EEPROMER(UART_Data, 0x01,'r', 68);
+        case 'h':
+          EEPROMER(UART_Data, 0x01,'r', 68+(whichdevice=='0'?0:69));
           LoRa_Settings.Mote_Class = UART_Data[0];
           if(LoRa_Settings.Mote_Class == 0x00)
           {

--- a/RFM95.cpp
+++ b/RFM95.cpp
@@ -128,8 +128,11 @@ void RFM_Send_Package(sBuffer *RFM_Tx_Package, sSettings *LoRa_Settings)
   RFM_Write(0x0D,RFM_Tx_Location);
 
   //Write Payload to FiFo
+  //Serial.println(RFM_Tx_Package->Counter);
+  //Serial.print("Addr: ");UART_Send_Data(RFM_Tx_Package->Data, 42);UART_Send_Newline();
   for (i = 0;i < RFM_Tx_Package->Counter; i++)
   {
+    //UART_Send_Data(RFM_Tx_Package->Data, i);UART_Send_Newline();
     RFM_Write(0x00, RFM_Tx_Package->Data[i]);
   }
 

--- a/RTC.h
+++ b/RTC.h
@@ -1,0 +1,67 @@
+//#include <avr/pgmspace.h>
+//#include <elapsedMillis.h>
+#include <Time.h>
+#include <Wire.h>
+#include <MCP7940RTC.h>
+
+//#define LED_BUILTIN 9 // mini-wireless board LED pin #
+//#define LED_ON digitalWrite(LED_BUILTIN,1)
+//#define LED_OFF digitalWrite(LED_BUILTIN,0)
+
+//#define RTC_INTERRUPT_PIN 3                     // arduino hardware interrupt pin, (i.e, D3 for miniWireless)
+
+
+#define YY 2017  // no need to change these; they're just used for testing. 
+#define MO 1  //Note the number sequences for easy reading screens
+#define DD 2
+#define HH 3
+#define MM 4
+#define SEC 0
+
+MCP7940RTC *RTCchip; // see the call to new() and the comments above.
+
+//elapsedMillis elapsedms; // relatively new in Arduino
+
+volatile boolean rtcInterruptFlag=0; // volatile:stevech
+
+//void ISRrtc() {  // interrupt service routine, just set flag
+//  rtcInterruptFlag = true;
+//}
+
+
+void setAlarmNextSecond(int seconds)  {
+  //uint8_t s = RTCchip->getSecond();   //get current second 0..59
+
+  //if (seconds > 1)
+  //  while (s == RTCchip->getSecond()) // for the sake of this test program, alarm on start of a seconds
+   // {
+    //  Serial.println("...");
+     // delay(1); // don't pound the RTC with I2C commands
+    //}
+  RTCchip->setAlarm0(now() + seconds);  // set next alarm time  
+}
+
+void setNewTimeRTC(int yr, int mo, int dy, int hr, int mn, int sec) {
+  tmElements_t tm1;
+  tm1.Year     =(yr-1970);
+  tm1.Month     =mo;
+  tm1.Day       =dy;
+  tm1.Hour      =hr;
+  tm1.Minute    =mn;
+  tm1.Second    =sec;
+  time_t t = makeTime(tm1);
+  RTCchip->setTimeRTC(t);
+}
+
+void RTCsetup() {
+  pinMode(RTC_INTERRUPT_PIN, INPUT_PULLUP);     // INPUT also sufficient, if we have our own on-board discrete pullup
+ // pinMode(LED_BUILTIN,  OUTPUT);
+ // LED_ON;
+  
+  RTCchip = new MCP7940RTC();  // see the comment block in setup() on this non-static class
+  setNewTimeRTC(YY, MO, DD, HH, MM, SEC);  // Set RTC chip time, (year, month, day, hour, minute, second)
+  setTime(HH,MM,SEC,DD,MO,YY);       // Set Arduino library system time (not RTC chip)
+  
+  delay(250);
+ // LED_OFF;
+}

--- a/Struct.h
+++ b/Struct.h
@@ -85,16 +85,6 @@ typedef struct {
 } sSettings;
 
 
-typedef struct{
-  //modulation
-  //bandwidth
-  //spreading factor
-  unsigned char *NwkSKey;
-  unsigned char *AppSKey;
-  unsigned char *DevAddr;
-  unsigned int  *Frame_Counter;
-  
-}VipimoSettings;
 
 #endif
 

--- a/Struct.h
+++ b/Struct.h
@@ -59,6 +59,7 @@ typedef struct {
     unsigned char *NetID;
 } sLoRa_OTAA;
 
+
 //Struct to store information of a LoRaWAN message to transmit or received
 typedef struct{
     unsigned char MAC_Header;
@@ -84,6 +85,16 @@ typedef struct {
 } sSettings;
 
 
+typedef struct{
+  //modulation
+  //bandwidth
+  //spreading factor
+  unsigned char *NwkSKey;
+  unsigned char *AppSKey;
+  unsigned char *DevAddr;
+  unsigned int  *Frame_Counter;
+  
+}VipimoSettings;
 
 #endif
 

--- a/config.h
+++ b/config.h
@@ -1,0 +1,41 @@
+//#define SERIALDEBUG
+
+#define pulseInterruptPin 2 //pin3 is available only for the RTC
+
+#define PULSECOUNTER   //#define doorSensor or #define PULSECOUNTER
+//#define doorSensor
+
+
+//#define RTC
+#ifdef RTC
+  #define RTC_INTERRUPT_PIN 3 
+ // #define YY 2017
+ // #define MO 06
+ // #define DD 21
+ // #define HH 12
+ // #define MM 00
+ // #define SEC 00
+#endif
+
+
+//#include "transmitConfig.h"
+#ifdef doorSensor
+  #include "doorSensorConfig.h"
+#endif
+
+//#define TEMPERATURE
+
+#define POWERMAN
+
+//#define LIGHTSENSORS
+
+
+#define TRUE 1
+#define FALSE 0
+
+//#define E_EPROM   //store config to EEPROM
+
+//#define TESTING
+
+
+

--- a/functions.h
+++ b/functions.h
@@ -1,0 +1,164 @@
+#define TTN_OR_KCS A1
+unsigned long int pulses = 0;
+
+
+int configvalueAddr(int addr)
+{
+  if(digitalRead(TTN_OR_KCS) == 0)return addr;
+  return  addr += 69;
+}
+
+int configvalueAddrfromletter(char addr)
+{
+  return 61 + (addr - 'a') + 69;
+}
+
+/*
+ * 0   1    N/A     N/A     Fixed value: 0x24
+1..12  12   N/A     N/A     Filler
+13..14  2   MSB first Signed    Value of analog input 1. For default situation: current trough 50 ohms resistor, measured as 11 bits value such that 2048 counts correspond to 1.024V. 1 count corresponds to 0.0005V, which corresponds to 0.01mA. To get the value in milliamps, divide by 100.
+15      1   N/A     N/A     Status of digital input 1. Value: 0x43 when open or high; 0x41 when closed or low.
+16..17  2   MSB first Signed    Value of analog input 2. For default situation: current trough 50 ohms resistor, measured as 11 bits value such that 2048 counts correspond to 1.024V. 1 count corresponds to 0.0005V, which corresponds to 0.01mA. To get the value in milliamps, divide by 100.
+18      1   N/A     N/A     Status of digital input 2. Value: 0x43 when open or high; 0x41 when closed or low.
+19..22  4   MSB first Unsigned  Digital input 1. Counter value of the pulse counter.
+23..24  2   MSB first Unsigned  Digital input 2. Counter value of the pulse counter.
+25..26  2   MSB first Signed    Temperature. Multiply by 0.0625 to get the temperature in degrees Celcius. Special value: 0x8000 indicates that no temperature sensor was found.
+27..28  2   LSB first Unsigned  Battery voltage. Multiply by 6.35 to get the voltage in millivolts.
+ */
+
+void transmitpacket(sBuffer *RFM_Buffer)        //create the packet to TX...
+{
+  unsigned char i;
+  RFM_Buffer->Counter = 29;
+  for(i = 0x01; i < 29; i++)
+  {
+    RFM_Buffer->Data[i] = 0x00;
+  }
+
+  Serial.println(sizeof (long int));
+  Serial.println(pulses);
+  //add pulses...
+  RFM_Buffer->Data[19] = (pulses & 0xff000000) >> 24; 
+  RFM_Buffer->Data[20] = (pulses & 0x00ff0000) >> 16;
+  RFM_Buffer->Data[21] = (pulses & 0x0000ff00) >> 8;
+  RFM_Buffer->Data[22] = (pulses & 0x000000ff) >> 0;
+
+  
+ // RFM_Buffer->Counter = 0x1D;
+  #ifdef SERIALDEBUG
+ // UART_Send_Data(pulses,29);
+  Serial.write("Data ");  
+  UART_Send_Data(RFM_Buffer->Data,29);
+  UART_Send_Newline();
+  #endif
+}
+
+
+void transmitdata()
+  {
+
+  cli();
+  //Serial.print("is Tx...");
+ // Serial.println(Tx_done);
+  //count_enable = false;
+  if(Tx_done == false)return;
+    /*
+
+EEPROMER(NwkSKey, 16, 'r', 4);
+  EEPROMER(AppSKey, 16, 'r', 20);
+  EEPROMER(Address_Tx, 4, 'r', configvalueAddr(0));
+  EEPROMER(DevEUI, 8, 'r', 60);
+  EEPROMER(AppEUI, 8, 'r',52);
+   EEPROMER(AppKey, 16, 'r',36);
+EEPROMER(AppSKey, 16, 'r', 20);*/
+    //ABP/OTAA
+   unsigned char abporotaa[1];
+      EEPROMER(Address_Tx, 4, 'r', configvalueAddr(0));
+      EEPROMER(NwkSKey, 16, 'r', configvalueAddr(4));
+      EEPROMER(AppSKey, 16, 'r', configvalueAddr(20));
+      Session_Data = {NwkSKey, AppSKey, Address_Tx, &Frame_Counter_Tx};
+      EEPROMER(DevEUI, 8, 'r', configvalueAddr(60));
+      EEPROMER(AppEUI, 8, 'r', configvalueAddr(52));
+      EEPROMER(AppKey, 16, 'r', configvalueAddr(36));
+      OTAA_Data = {DevEUI, AppEUI, AppKey, DevNonce, AppNonce, NetID};
+
+      Data_Tx[0] = 0x24;
+      Buffer_Tx.Data = Data_Tx;//{Data_Tx, 0x00};
+      transmitpacket(&Buffer_Tx);
+
+      //ABP/OTAA
+      if(abporotaa[0] == 0x00)//ABP
+      {
+        RFM_Command_Status = NEW_RFM_COMMAND;
+        //Type A mote transmit receive cycle
+       // if((RFM_Command_Status == NEW_RFM_COMMAND || RFM_Command_Status == JOIN) && LoRa_Settings.Mote_Class == 0x00)
+        //{
+          //LoRa cycle
+          
+          LORA_Cycle(&Buffer_Tx, &Buffer_Rx, &RFM_Command_Status, &Session_Data, &OTAA_Data, &Message_Rx, &LoRa_Settings);
+    
+          RFM_Command_Status = NO_RFM_COMMAND;
+       // }
+      }else///////////////rq OTAA
+      {
+          //Serial.println("in OTAA....");
+          //Type C mote transmit and receive handling
+          if(LoRa_Settings.Mote_Class == 0x01)
+          {
+            if(RFM_Command_Status == JOIN)
+            {
+              //Start join precedure
+              LoRa_Send_JoinReq(&OTAA_Data, &LoRa_Settings);
+      
+              //Clear RFM_Command
+              RFM_Command_Status = NO_RFM_COMMAND;
+            }
+      
+            //Transmit
+            if(RFM_Command_Status == NEW_RFM_COMMAND)
+            {
+              //Lora send data
+              LORA_Send_Data(&Buffer_Tx, &Session_Data, &LoRa_Settings);
+      
+              RFM_Command_Status = NO_RFM_COMMAND;
+            }
+      
+            //Receive
+            if(digitalRead(DIO0) == HIGH)
+            {
+              //Get data
+              LORA_Receive_Data(&Buffer_Rx, &Session_Data, &OTAA_Data, &Message_Rx, &LoRa_Settings);
+      
+              Rx_Status = NEW_RX;
+            }
+          }
+          
+        
+      }
+  
+      //If there is new data
+      if(Rx_Status == NEW_RX)
+      {
+      //Check if there is data in the received message
+          if(Buffer_Rx.Counter != 0x00)
+      {
+        UART_Send_Data(Buffer_Rx.Data,Buffer_Rx.Counter);
+      }
+          else
+          {
+            Serial.write("No data");
+          }
+  
+          UART_Send_Newline();
+          UART_Send_Newline();
+  
+          Rx_Status = NO_RX;
+      }
+    Tx_done = true; //done transmitting;
+    //count_enable = true;
+    sei();
+
+    //  cleartimetotransmit();
+      
+      //j1s 00000000
+  }

--- a/loader.h
+++ b/loader.h
@@ -1,0 +1,26 @@
+#include "functions.h"
+#ifdef POWERMAN
+  #include "powerMan.h"
+#endif
+
+#ifdef RTC
+  #include "RTC.h"
+#endif
+
+#ifdef doorSensor
+  #include "doorSensor.h"
+#endif
+
+#ifdef PULSECOUNTER
+  #include "pulseCounter.h"
+#endif
+
+#ifdef LIGHTSENSORS
+  #include "lightSensors.h"
+#endif
+
+#ifdef TEMPERATURE
+  #include "temperature.h"
+#endif
+
+//#include "transmit.h"

--- a/powerMan.h
+++ b/powerMan.h
@@ -1,0 +1,137 @@
+//#include <LowPower.h>
+#include <avr/sleep.h>
+#include <avr/wdt.h>
+
+bool hz_flag;
+int secs = 0;
+int nextIntr;
+//byte timetotransmit = 1; //true
+
+void powermanSetup()
+{
+  wdt_disable();
+}
+
+void systemSleep()
+{
+  ADCSRA &= ~_BV(ADEN);         // ADC disabled
+
+  /*
+  * Possible sleep modes are (see sleep.h):
+  #define SLEEP_MODE_IDLE         (0)
+  #define SLEEP_MODE_ADC          _BV(SM0)
+  #define SLEEP_MODE_PWR_DOWN     _BV(SM1)
+  #define SLEEP_MODE_PWR_SAVE     (_BV(SM0) | _BV(SM1))
+  #define SLEEP_MODE_STANDBY      (_BV(SM1) | _BV(SM2))
+  #define SLEEP_MODE_EXT_STANDBY  (_BV(SM0) | _BV(SM1) | _BV(SM2))
+  */
+  set_sleep_mode(SLEEP_MODE_PWR_DOWN);
+
+  /*
+   * This code is from the documentation in avr/sleep.h
+   */
+  cli();
+  // Only go to sleep if there was no watchdog interrupt.
+  //if (!hz_flag)
+ // {
+    sleep_enable();
+    sei();
+    sleep_cpu();
+    sleep_disable();
+  //}
+  sei();
+
+  ADCSRA |= _BV(ADEN);          // ADC enabled
+}
+
+#define my_wdt_enable(value)   \
+__asm__ __volatile__ (  \
+    "in __tmp_reg__,__SREG__" "\n\t"    \
+    "cli" "\n\t"    \
+    "wdr" "\n\t"    \
+    "sts %0,%1" "\n\t"  \
+    "out __SREG__,__tmp_reg__" "\n\t"   \
+    "sts %0,%2" "\n\t" \
+    : /* no outputs */  \
+    : "M" (_SFR_MEM_ADDR(_WD_CONTROL_REG)), \
+      "r" (_BV(_WD_CHANGE_BIT) | _BV(WDE)), \
+      "r" ((uint8_t) (((value & 0x08) ? _WD_PS3_MASK : 0x00) | \
+          _BV(WDE) | _BV(WDIE) | (value & 0x07)) ) \
+    : "r0"  \
+)
+
+void setupWatchdog()
+{
+  /*
+   * If you change this, remember to change secs += 8; in ISR(WDT_vect)
+   */
+  my_wdt_enable(WDTO_8S);
+}
+
+ISR(WDT_vect)
+{
+
+ /**/
+ cli();
+ secs += 8;
+ #ifndef RTC
+ 
+  if(secs >= nextIntr)
+  {
+    secs = 0;
+    wdt_disable();
+//    timetotransmit = 1;
+    transmitdata();
+  }else
+  {
+    
+    interrupts();
+    wdt_reset();
+  }
+  #endif
+ #ifdef RTC
+     interrupts();
+    wdt_reset();
+    setupWatchdog();
+    systemSleep();
+   #endif
+ 
+  #ifdef SERIALDEBUG
+     // Serial.println("....................ISR(WDT_vect).................");
+      Serial.println(secs);
+      delay(10);
+      //Serial.println(":...ISR(WDT_vect)");
+  #endif
+  //setupWatchdog();
+  
+}
+
+void powerthisDownNow()
+{
+    powerthisDownNow_start:
+      interrupts();
+      setupWatchdog();
+      systemSleep();
+    goto powerthisDownNow_start;    //system is only woken up by interrupts.
+    /*
+     * Try if this setup works this way...........................................ok
+     * Set watchdog timer to 8 secs. Does it still work?
+     * Try if it works with RTC,,,
+     * Add door sensor,
+     * Add pulse counter,
+     * Set it up and leave for the weekend and observe the battery level.
+     * Clean up code,
+     * Push 
+     * Document...
+     */
+    
+}
+
+void powerthisDown()
+{
+     powerthisDownNow();
+}
+
+
+
+

--- a/pulseCounter.h
+++ b/pulseCounter.h
@@ -1,0 +1,194 @@
+#define pulseCounterPin pulseInterruptPin
+//unsigned long int pulses = 0;
+//byte waspulse = true;
+long startedmillis = 0;
+long openingmillis = 0;
+byte doortouched = false;
+byte doorstatus = 0;
+long openmillis = 0;
+
+#define TRANSMITPIN 12
+#define DOOR_OR_PULSE A2
+
+#define DOORPIN 2
+
+void pulseCounterDebug()
+{
+  #ifdef SERIALDEBUG
+   // sprintf(buffer, "pulses:%d", pulses);
+   // Serial.println(buffer);
+    //Serial.print("pulses:"); Serial.println(pulses);
+    //Serial.print("A2:"); Serial.println(digitalRead(A2));
+    //Serial.print("TRANSMITPIN:"); Serial.println(digitalRead(TRANSMITPIN));
+  #endif
+}
+
+void pulseCounterISR()
+{
+  #ifdef TESTING
+   // Serial.println("pulse ISR...");
+  #endif
+  //use RTC to count...
+  wdt_disable();
+  //if(millis() - startedmillis <50 /*(started == 0*/)
+  if(count_enable == false /*(started == 0*/)
+    {
+      
+    }
+   else
+   {
+      #ifdef TESTING
+           // Serial.println("pulse ISR ++...");
+     #endif
+      if(digitalRead(TRANSMITPIN) == true)    //is TX button
+      {
+        //transmit
+//        if(timetotransmit == 0)//no timer ISR
+ //         timetotransmit = 2;
+          #ifndef TESTING
+              transmitdata();
+              Frame_Counter_Tx++;         //frame counter not incremented when TX is triggered from here
+              Serial.println(Frame_Counter_Tx);
+          #endif
+          #ifdef TESTING
+            Serial.println("is transmit...");
+            transmitdata();
+            
+            Serial.println(Frame_Counter_Tx);
+          #endif
+      }else
+      {
+        
+        //door or pulse
+        //Serial.println(digitalRead(DOOR_OR_PULSE));
+       if(digitalRead(DOOR_OR_PULSE) == true) //pulse
+       {
+          
+          #ifdef TESTING
+            //Serial.println("is PULSE...");
+          #endif
+          pulses++;
+          //waspulse = true;
+       }else  //door........................................................require...............................
+       {
+            #ifdef TESTING
+              Serial.println("is door...");
+            #endif
+            if(doortouched == false)startedmillis = 0;
+            doortouched = true;
+            if(startedmillis ==0 )startedmillis = millis();       //when first interrupt was received
+            if(millis() - startedmillis < 200);                   //debounce. Value obtained from empirical data
+            else
+            {
+              //after debouncing, we can now get the door status
+              doorstatus = digitalRead(DOORPIN);
+              Serial.print("doorstatus: ");
+              Serial.println(doorstatus);
+              if(doorstatus == 1)     //using NC switch and door is NC, doorstatus is 1 when door is opened
+              {
+                openingmillis = startedmillis;
+                startedmillis = 0;
+                pulses++;
+              }else //if door is closing
+              {
+                startedmillis = 0 ;
+                 unsigned long tmpmillis = millis();
+                 openmillis += millis() - openingmillis;
+              }
+              
+            }
+       }
+        
+      }
+   }
+  
+  
+}
+
+void setTxInterval()
+{
+  ///int nextIntr;
+  
+  EEPROM.get(70+69, nextIntr);
+ // cli();
+  Serial.print("tx interval: ");
+  Serial.println(nextIntr);
+  //Serial.println("..");
+  #ifdef RTC
+  setAlarmNextSecond(nextIntr);
+  #endif
+  //interrupts();
+}
+
+void ISRrtc() {  // interrupt service routine
+  wdt_reset();
+  cli();
+  wdt_disable();
+   setTxInterval();
+  //timetotransmit = 1;
+  #ifdef SERIALDEBUG
+  Serial.println("***");
+ // Serial.println(nextIntr);
+  #endif
+}
+
+
+
+void pulseCounterSetup()
+{
+  //pinMode(pulseCounterPin, INPUT_PULLUP);
+  EEPROM.get(70+69, nextIntr);
+  startedmillis = millis();
+  pinMode(pulseCounterPin, INPUT_PULLUP);
+  pinMode(DOOR_OR_PULSE, INPUT_PULLUP);
+  pinMode(TTN_OR_KCS , INPUT_PULLUP);
+  pinMode(TRANSMITPIN, INPUT_PULLUP);
+  attachInterrupt(digitalPinToInterrupt(pulseCounterPin), pulseCounterISR, RISING);
+
+
+  //transmission
+  #ifdef RTC
+  attachInterrupt(digitalPinToInterrupt(RTC_INTERRUPT_PIN), ISRrtc, FALLING);
+   //int nextIntr = (int) TRANSMITINTERVALSECS;
+ // Serial.println(nextIntr);
+ // setAlarmNextSecond(nextIntr);
+  ///int pass;
+ // int n;
+  //uint32_t millisStart, mark;
+
+  //Serial.println(F("Begin loop()"));
+  
+  setNewTimeRTC(YY, MO, DD, HH, MM, SEC);  // Set RTC chip time, (year, month, day, hour, minute, second)
+  setTime(HH,MM,SEC,DD,MO,YY);       // Set system time (not RTC chip)
+  setTxInterval();
+  #endif
+}
+
+
+
+
+
+/*
+byte istimetoTransmit()
+{
+  return timetotransmit;
+}
+*/
+
+byte whichchannel()
+{
+  return digitalRead(TTN_OR_KCS);
+}
+
+
+/*
+void cleartimetotransmit()
+{
+  #ifdef RTC
+  //Serial.println(timetotransmit);
+  if(timetotransmit != 2) setTxInterval();
+  #endif
+  timetotransmit = false;
+}
+*/
+


### PR DESCRIPTION
The changes are to enable saving configuration values to EEPROM so they don't have to be either stored in code nor written everytime the device is restarted as is the case now.

When you enter a command
> mac set drtx 01
the value goes to EEPROM and is read from there the next time the device restarts or when it's reprogrammed.